### PR TITLE
Reverting to a previous change.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3835,6 +3835,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
@@ -18728,9 +18739,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -23787,6 +23800,13 @@
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "requires": {
         "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+        }
       }
     },
     "ansi-html": {
@@ -35535,9 +35555,11 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "optional": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -10,7 +10,7 @@ const sleep = (time) => new Promise((res) => setTimeout(res, time));
 export async function fetch(url) {
   const [, search = ""] = url.split("?");
   const params = new URLSearchParams(search);
-  await sleep(400);
+  await sleep(800);
   // const symbols = new Set((params.get("symbols") || "").split(","));
   const base = params.get("base");
   const rates = exchangeRates[base];


### PR DESCRIPTION
I have listed the cloned and forked repo's previous changes. I reverted the change by using "git reset <changeID>".

I was unable to launch either version receiving similar errors:
Starting the development server...

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:69:19)
    at Object.createHash (node:crypto:138:10)
    at module.exports (/home/dschwartz/bootcamp/exchangeRate/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/dschwartz/bootcamp/exchangeRate/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/home/dschwartz/bootcamp/exchangeRate/node_modules/webpack/lib/NormalModule.js:471:10)
    at /home/dschwartz/bootcamp/exchangeRate/node_modules/webpack/lib/NormalModule.js:503:5
    at /home/dschwartz/bootcamp/exchangeRate/node_modules/webpack/lib/NormalModule.js:358:12
    at /home/dschwartz/bootcamp/exchangeRate/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/home/dschwartz/bootcamp/exchangeRate/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/home/dschwartz/bootcamp/exchangeRate/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
/home/dschwartz/bootcamp/exchangeRate/node_modules/react-scripts/scripts/start.js:19
  throw err;
  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:69:19)
    at Object.createHash (node:crypto:138:10)
    at module.exports (/home/dschwartz/bootcamp/exchangeRate/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/dschwartz/bootcamp/exchangeRate/node_modules/webpack/lib/NormalModule.js:417:16)
    at /home/dschwartz/bootcamp/exchangeRate/node_modules/webpack/lib/NormalModule.js:452:10
    at /home/dschwartz/bootcamp/exchangeRate/node_modules/webpack/lib/NormalModule.js:323:13
    at /home/dschwartz/bootcamp/exchangeRate/node_modules/loader-runner/lib/LoaderRunner.js:367:11
    at /home/dschwartz/bootcamp/exchangeRate/node_modules/loader-runner/lib/LoaderRunner.js:233:18
    at context.callback (/home/dschwartz/bootcamp/exchangeRate/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /home/dschwartz/bootcamp/exchangeRate/node_modules/babel-loader/lib/index.js:59:103 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}